### PR TITLE
Fix detail programme CRUD and activity handling

### DIFF
--- a/src/routes/activitiesRouter.ts
+++ b/src/routes/activitiesRouter.ts
@@ -12,21 +12,22 @@ export const activitiesRouter = express.Router();
 const prisma = new PrismaClient();
 
 async function renderEditActivity(
-	res: express.Response,
-	activityId: string,
-	req: express.Request
+        res: express.Response,
+        activityId: string,
+        req: express.Request
 ) {
-	const activity = await prisma.activities.findUniqueOrThrow({
-		where: {
-			id: activityId,
-		},
-	});
+        const activity = await prisma.activities.findUniqueOrThrow({
+                where: {
+                        id: activityId,
+                },
+        });
 
-	const detailprogramm = await prisma.detailprogramme.findUniqueOrThrow({
-		where: {
-			activityId: activityId,
-		},
-	});
+        const detailprogramm =
+                (await prisma.detailprogramme.findUnique({
+                where: {
+                        activityId: activityId,
+                },
+                })) || undefined;
 
 	const mails = await prisma.mails.findMany({
 		where: {

--- a/src/routes/detailprogrammeRouter.ts
+++ b/src/routes/detailprogrammeRouter.ts
@@ -1,25 +1,46 @@
 import { activities, detailprogramme, PrismaClient } from '@prisma/client';
-import express, { Request } from 'express';
-import { activitiesEntry, detailprogrammEntry } from '../types/prismaEntry';
+import express from 'express';
+import { detailprogrammEntry } from '../types/prismaEntry';
 
 export const detailprogrammeRouter = express.Router();
 const prisma = new PrismaClient();
 
-async function updateActivity(detailprogrammEntry: detailprogramme) {
-	let activity = await prisma.activities.findUniqueOrThrow({
-		where: {
-			id: detailprogrammEntry.activityId,
-		},
-	});
-	activity.detailprogrammId = detailprogrammEntry.id as string;
-	const newActivity: activitiesEntry = activity;
-	delete newActivity.id;
-	await prisma.activities.update({
-		data: newActivity,
-		where: {
-			id: detailprogrammEntry.activityId,
-		},
-	});
+function normalizeToArray(value: string | string[] | undefined): string[] {
+        if (typeof value === 'undefined') {
+                return [];
+        }
+        return Array.isArray(value) ? value : [value];
+}
+
+function mapDetailprogrammBody(
+        body: any,
+        currentDetailprogramm?: detailprogramm
+): detailprogrammEntry {
+        const {
+                date,
+                starttime,
+                endtime,
+                location,
+                responsible,
+                material,
+                zeit,
+                ablauf,
+                activityId = currentDetailprogramm?.activityId,
+                anschlagAbmeldenBis,
+        } = body;
+
+        return {
+                date,
+                starttime,
+                endtime,
+                location,
+                responsible,
+                material,
+                zeit: normalizeToArray(zeit),
+                ablauf: normalizeToArray(ablauf),
+                AbmeldenBis: anschlagAbmeldenBis || currentDetailprogramm?.AbmeldenBis,
+                activityId,
+        } as detailprogrammEntry;
 }
 
 detailprogrammeRouter.get(
@@ -40,28 +61,28 @@ detailprogrammeRouter.get(
 		res: express.Response,
 		next: express.NextFunction
 	) {
-		let detailprogramm: detailprogramme = {} as detailprogramme;
-		let detailprogrammId = '';
-		let activity;
-		if (req.query.activityId != undefined) {
-			activity = await prisma.activities.findUniqueOrThrow({
-				where: {
-					id: req.query.activityId as string,
-				},
-			});
-			detailprogrammId = activity.detailprogrammId as string;
-		}
-		if (req.query.id != undefined || detailprogrammId != '') {
-			try {
-				detailprogramm = await prisma.detailprogramme.findUniqueOrThrow({
-					where: {
-						id: (req.query.id as string) || (detailprogrammId as string),
-					},
-				});
-			} catch (error) {
-				next(error);
-			}
-		}
+                let detailprogramm: detailprogramme = {} as detailprogramme;
+                let activity: activities | null = null;
+
+                if (req.query.activityId != undefined) {
+                        activity = await prisma.activities.findUniqueOrThrow({
+                                where: {
+                                        id: req.query.activityId as string,
+                                },
+                        });
+                }
+
+                if (req.query.id != undefined) {
+                        try {
+                                detailprogramm = await prisma.detailprogramme.findUniqueOrThrow({
+                                        where: {
+                                                id: req.query.id as string,
+                                        },
+                                });
+                        } catch (error) {
+                                next(error);
+                        }
+                }
 		res.render('editDetailprogramm', {
 			user: req.user,
 			page: 'Detailprogramme',
@@ -77,11 +98,12 @@ detailprogrammeRouter.post(
 		res: express.Response,
 		next: express.NextFunction
 	) => {
-		try {
-			const newEntry: detailprogramme = await prisma.detailprogramme.create({
-				data: req.body,
-			});
-			await updateActivity(newEntry);
+                try {
+                        const detailprogrammEntry = mapDetailprogrammBody(req.body);
+
+                        const newEntry: detailprogramme = await prisma.detailprogramme.create({
+                                data: detailprogrammEntry,
+                        });
 
 			res.render('editDetailprogramm', {
 				user: req.user,
@@ -104,23 +126,36 @@ detailprogrammeRouter.post(
 		res: express.Response,
 		next: express.NextFunction
 	) => {
-		try {
-			const detailprogrammEntry: detailprogrammEntry = req.body;
+                try {
+                        const existingDetailprogramm = await prisma.detailprogramme.findUniqueOrThrow({
+                                where: {
+                                        id: req.query.id as string,
+                                },
+                        });
 
-			await prisma.detailprogramme.update({
-				data: detailprogrammEntry,
-				where: {
-					id: req.query.id as string,
-				},
-			});
+                        const detailprogrammEntry = mapDetailprogrammBody(
+                                req.body,
+                                existingDetailprogramm
+                        );
 
-			res.render('editDetailprogramm', {
-				user: req.user,
-				page: 'Detailprogramme',
-				detailprogramm: detailprogrammEntry,
-			});
-		} catch (error) {
-			next(error);
-		}
-	}
+                        await prisma.detailprogramme.update({
+                                data: detailprogrammEntry,
+                                where: {
+                                        id: req.query.id as string,
+                                },
+                        });
+
+                        res.render('editDetailprogramm', {
+                                user: req.user,
+                                page: 'Detailprogramme',
+                                detailprogramm: await prisma.detailprogramme.findUniqueOrThrow({
+                                        where: {
+                                                id: req.query.id as string,
+                                        },
+                                }),
+                        });
+                } catch (error) {
+                        next(error);
+                }
+        }
 );

--- a/src/routes/detailprogrammeRouter.ts
+++ b/src/routes/detailprogrammeRouter.ts
@@ -44,23 +44,23 @@ function mapDetailprogrammBody(
 }
 
 detailprogrammeRouter.get(
-	'/',
-	async function (req: express.Request, res: express.Response) {
-		res.render('detailprogramme', {
-			user: req.user,
-			page: 'Detailprogramme',
-			detailprogramme: await prisma.detailprogramme.findMany(),
-		});
-	}
+        '/',
+        async function (req: express.Request, res: express.Response) {
+                res.render('detailprogramme', {
+                        user: req.user,
+                        page: 'Detailprogramme',
+                        detailprogramme: await prisma.detailprogramme.findMany(),
+                });
+        }
 );
 
 detailprogrammeRouter.get(
-	'/edit',
-	async function (
-		req: express.Request,
-		res: express.Response,
-		next: express.NextFunction
-	) {
+        '/edit',
+        async function (
+                req: express.Request,
+                res: express.Response,
+                next: express.NextFunction
+        ) {
                 let detailprogramm: detailprogramme = {} as detailprogramme;
                 let activity: activities | null = null;
 
@@ -70,6 +70,16 @@ detailprogrammeRouter.get(
                                         id: req.query.activityId as string,
                                 },
                         });
+
+                        const activityDetailprogramm = await prisma.detailprogramme.findUnique({
+                                where: {
+                                        activityId: activity.id,
+                                },
+                        });
+
+                        if (activityDetailprogramm) {
+                                detailprogramm = activityDetailprogramm;
+                        }
                 }
 
                 if (req.query.id != undefined) {
@@ -83,13 +93,13 @@ detailprogrammeRouter.get(
                                 next(error);
                         }
                 }
-		res.render('editDetailprogramm', {
-			user: req.user,
-			page: 'Detailprogramme',
-			detailprogramm: detailprogramm,
-			activity: activity,
-		});
-	}
+                res.render('editDetailprogramm', {
+                        user: req.user,
+                        page: 'Detailprogramme',
+                        detailprogramm: detailprogramm,
+                        activity: activity,
+                });
+        }
 );
 detailprogrammeRouter.post(
 	'/create',

--- a/src/views/editActivity.ejs
+++ b/src/views/editActivity.ejs
@@ -17,12 +17,10 @@
     <label for="name">Name</label>
     <input type="text" name="name" required value="<%= activity.name %>">
 
-    <input type="text" name="detailprogrammId" hidden value="<%= activity.detailprogrammId %>">
-
     <button class=" border-2 rounded-full py-2 px-4 " type="submit" id="save" onclick="confirmSave()">Speichern</button>
   </form>
 
-  <% if(activity.detailprogrammId == "" && Object.keys(activity).length > 0) { %>
+  <% if(!detailprogramm && Object.keys(activity).length > 0) { %>
   <div>
     <button>
       <a href="/detailprogramme/edit?activityId=<%= activity.id %>">Neues DP</a>

--- a/src/views/editDetailprogramm.ejs
+++ b/src/views/editDetailprogramm.ejs
@@ -46,7 +46,7 @@
     <input type="text" name="anschlagAbmeldenMail" value="<%= detailprogramm.anschlagAbmeldenMail %>">
 
     <% if(typeof activity != "undefined") { %>
-    <input type="activityId" name="activityId" value="<%= activity.id %>" hidden>
+    <input type="hidden" name="activityId" value="<%= activity.id %>">
     <% } %>
 
     <button class=" border-2 rounded-full py-2 px-4 " type="submit" id="save" onclick="confirmSave()">Speichern</button>


### PR DESCRIPTION
## Summary
- normalize detail programme payloads and preserve activity linkage during create/update
- safely render activities when no linked detail programme exists

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243a9fce1c832e8abe69d9968c7208)